### PR TITLE
PSG-4766 stop job always

### DIFF
--- a/.github/workflows/ec2-runner-stop.yaml
+++ b/.github/workflows/ec2-runner-stop.yaml
@@ -21,7 +21,6 @@ on:
 jobs:
   stop-runner:
     runs-on: ubuntu-latest
-    if: ${{ always() }} # required to stop the runner even if previous jobs failed or are cancelled
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ start-runner:
 
 ```yaml
 stop-runner:
+    if: ${{ always() }} # required to stop the runner even if previous jobs failed or are cancelled
     needs:
       - start-runner # required to get output from the start-runner job
       - name_of_main_jobs # required to wait when the main job/jobs is/are done.


### PR DESCRIPTION
# Description

Need to add the `if: always` statement on the **stop** caller workflow and not in the reusable one.